### PR TITLE
Fixed dendrogram bug

### DIFF
--- a/iPSCeq-server.R
+++ b/iPSCeq-server.R
@@ -9058,7 +9058,7 @@ iPSCeqServer <- function(input, output, session) {
         validate(
           need(input$goclust != "", "")
         )
-        if (length(clustout()) == 8) {
+        if (length(clustout()) == 5) {
           withProgress(message = "Creating gene dendrogram...", value = 0, {
             incProgress(1/2)
             geneTree <- clustout()[["geneTree"]]


### PR DESCRIPTION
This PR fixes a bug that prevented dendrograms from being displayed for bulk analysis.

From  @kelliwilson:

```
The issue can be replicated by this workflow.

Click on Bulk RNA-Seq
Check example_bulk
Click Load full dataset
Click Analysis in the upper panel
Click Clustering
Click Launch Clustering analysis
A plot is supposed to appear on the page, however nothing shows up.
```

