### PR TITLE
Seurat assay version

### DIFF
--- a/iPSCeq-modules.R
+++ b/iPSCeq-modules.R
@@ -3921,6 +3921,7 @@ LoadData <- function(input, output, session, maxSamples = Inf) {
   # SC-DGE-OVER - create seurat object for downstream analysis
   seurat_only <- reactive({
     # req(SubmitData$data_type, d$resType)
+    options(Seurat.object.assay.version = "v3")
     if(is.null(input$data_type) || input$data_type != "Single-cell" || 
        is.null(input$res) || is.null(ddsout())) return()
     withProgress(message = "Building Seurat analysis...", value = 0, {


### PR DESCRIPTION
In `seurat_sc` module `CalcAllSCV()` function does not work with Seurat Assay5 class, which is created by default during Seurat object creation in module `seurat_only`. Added a specification in module `seurat_only` to create a Seurat object with assay v3 (class Assay). 