### PR TITLE
fixed single cell WGCNA by removing sampleDF

### DIFF
--- a/iPSCeq-server.R
+++ b/iPSCeq-server.R
@@ -14104,10 +14104,10 @@ iPSCeqServer <- function(input, output, session) {
         rownames(moddf) <- seq_len(nrow(moddf))
         moddf$gene <- as.character(moddf$gene)
         moddf$module <- as.factor(moddf$module)
-        sampleDF <- data.frame(
-          sample = sampleTree$labels,
-          outlier = datColors$outlier
-        )
+        #sampleDF <- data.frame(
+        #  sample = sampleTree$labels,
+        #  outlier = datColors$outlier
+        #)
         disableWGCNAThreads()
         incProgress(1/3)
         return(


### PR DESCRIPTION
Edited clustout_sc wgcna clustering so that it will not create sampleDF object that is not used withing the function and is created with sampleTree$labels that is not defined for single cell clustering.
Commented out just in case, for now.