### PR TITLE
Corrected single-cell  gene expression clustering bug

### DIFF
--- a/iPSCeq-server.R
+++ b/iPSCeq-server.R
@@ -10382,11 +10382,11 @@ iPSCeqServer <- function(input, output, session) {
       sapply(temp_embs,function(X) ncol(getEmb(d$inD, X))) >= 2 &
         sapply(temp_embs,function(X) nrow(getEmb(d$inD, X))) == nrow(getMD(d$inD))
     ]
-    temp_embs <- toupper(temp_embs)
-    temp_embs <- gsub("TSNE", "tSNE", temp_embs)
+    #temp_embs <- toupper(temp_embs)
+    #temp_embs <- gsub("TSNE", "tSNE", temp_embs)
     selectInput("GOI_EmbType", label = "Cell embedding",
                 choices = temp_embs,
-                selected = temp_embs[temp_embs %in% c("tSNE","UMAP")][1])
+                selected = temp_embs[temp_embs %in% c("tsne","umap")][1])
   })
   
   # SC-DGE-GE - goi x-axis


### PR DESCRIPTION
output$GOI_EmbType creates a selection to choose dimmention reduction method for gene expression clustering. 
The Seurat object has all dimension reduction embeddings spelled with lower case letters. Therefore, I commented out parts of the code that convert them to upper case letters and therefore cause an error where the selection does not match the actual object. 