### PR TITLE
Adjust the size of the bulk RNA DGE heatmap

### DIFF
--- a/iPSCeq-server.R
+++ b/iPSCeq-server.R
@@ -8356,6 +8356,12 @@ iPSCeqServer <- function(input, output, session) {
   # BULK-DGE-GSE - heatmap
   output$heatplot1 <- renderPlotly({
     if(is.null(heattran2())) return()
+    nGenes = nrow(heattran2()$rescaled_mat)
+    if (nGenes > 1 & nGenes < 17) {
+      curHeight = 1000
+    } else {
+      curHeight = heattran2()$heatmapHeight
+    }
     isolate({
       p <- heatmaply(
         x = heattran2()$rescaled_mat,
@@ -8377,7 +8383,7 @@ iPSCeqServer <- function(input, output, session) {
         Colv = heattran2()$colDend,
         revC = T,
         width = 1000,
-        height = heattran2()$heatmapHeight,
+        height = curHeight,
         subplot_heights = heattran2()$subplotHeights
       ) %>%
         colorbar(


### PR DESCRIPTION
If the number of genes is in range from 2 to 16, the heatmap does not display.
In these cases made the size of the heatmap constant.